### PR TITLE
update(ZModemReceive.java): fix file locking issue

### DIFF
--- a/src/main/java/zmodem/xfer/zm/util/ZModemReceive.java
+++ b/src/main/java/zmodem/xfer/zm/util/ZModemReceive.java
@@ -130,6 +130,8 @@ public class ZModemReceive {
 						os.write(new Header(Format.HEX, ZModemCharacter.ZRINIT, recvOpt));
 						expect = Expect.NOTHING;
 						filename = null;
+						fileOs.flush();
+						fileOs.close();
 						fileOs = null;
 						break;
 					case ZDATA:


### PR DESCRIPTION
Add file output stream `flush()` and `close()` method calls when `ZEOF` header is received before setting file output stream to `null`. This will prevent the file from being locked indefinitely on the file system.